### PR TITLE
Added possibility to pick between use and useFirst

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,16 +54,31 @@ var shortcodes = {};
   emoticons = result;
 })();
 
+function getProtoFunction(fn) {
+  if (!fn) { return 'useFirst'; }
+  if (fn === 'use' || fn === 'useFirst') { return fn; }
+  throw new TypeError(
+    'Illegal invocation: `' + fn +
+    '` is not a valid value for modifiers. in `retext#use(emoji, options)`'
+  );
+}
+
+
 /* Attacher. */
-function emoji(options) {
+function emoji(rawOptions) {
+  var options = rawOptions || {};
   var Parser = this.Parser;
   var proto = Parser.prototype;
-  var convert = (options || {}).convert;
+  var convert = options.convert;
   var fn;
 
-  proto.useFirst('tokenizeSentence', emoticonModifier);
-  proto.useFirst('tokenizeSentence', emojiModifier);
-  proto.useFirst('tokenizeParagraph', affixEmoticonModifier);
+  var emojiModifierFn = getProtoFunction(options.emojiModifierFn);
+  var emoticonModifierFn = getProtoFunction(options.emoticonModifierFn);
+  var affixEmoticonModifierFn = getProtoFunction(options.affixEmoticonModifierFn);
+
+  proto[emojiModifierFn]('tokenizeSentence', emojiModifier);
+  proto[emoticonModifierFn]('tokenizeSentence', emoticonModifier);
+  proto[affixEmoticonModifierFn]('tokenizeParagraph', affixEmoticonModifier);
 
   if (convert !== null && convert !== undefined) {
     fn = fns[convert];

--- a/index.js
+++ b/index.js
@@ -55,14 +55,17 @@ var shortcodes = {};
 })();
 
 function getProtoFunction(fn) {
-  if (!fn) { return 'useFirst'; }
-  if (fn === 'use' || fn === 'useFirst') { return fn; }
+  if (!fn) {
+    return 'useFirst';
+  }
+  if (fn === 'use' || fn === 'useFirst') {
+    return fn;
+  }
   throw new TypeError(
     'Illegal invocation: `' + fn +
     '` is not a valid value for modifiers. in `retext#use(emoji, options)`'
   );
 }
-
 
 /* Attacher. */
 function emoji(rawOptions) {

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,11 @@ When `encode`, converts short-codes and emoticons to their unicode equivalent
 When `decode`, converts unicode emoji and emoticons to their short-code
 equivalent (`❤️` and `<3` to `:heart:`).
 
+###### `options.emojiModifierFn` | `options.emoticonModifierFn` | `options.affixEmoticonModifierFn`
+
+Can be 'use' or 'useFirst'. Defaults to useFirst when nothing is defined. These allow to change the behavior on the parsing.
+
+
 ### `EmoticonNode`
 
 `retext-emoji` adds a new node to [NLCST][]: `Emoticon` ([Symbol][]).

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,14 @@ When `encode`, converts short-codes and emoticons to their unicode equivalent
 When `decode`, converts unicode emoji and emoticons to their short-code
 equivalent (`❤️` and `<3` to `:heart:`).
 
-###### `options.emojiModifierFn` | `options.emoticonModifierFn` | `options.affixEmoticonModifierFn`
+###### `options.(plugin)ModifierFn`
 
-Can be 'use' or 'useFirst'. Defaults to useFirst when nothing is defined. These allow to change the behavior on the parsing.
+*   `options.emojiModifierFn` 
+*   `options.emoticonModifierFn` 
+*   `options.affixEmoticonModifierFn`
 
+Can be “use” or “useFirst”.  Defaults to useFirst when nothing is defined.
+These allow to change the behavior on the parsing.
 
 ### `EmoticonNode`
 

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,17 @@ test('toString()', function (t) {
     st.end();
   });
 
+  t.test('should throw when given invalid `modifier fn`', function (st) {
+    st.throws(
+      function () {
+        retext().use(emoji, {emojiModifierFn: 'InvalidFnName'}).freeze();
+      },
+      /Illegal invocation: `InvalidFnName` is not a valid value/
+    );
+
+    st.end();
+  });
+
   t.test('should classify emoticons', function (st) {
     var processor = retext().use(emoji);
     var tree = processor.parse('This makes me feel :).');
@@ -81,6 +92,33 @@ test('toString()', function (t) {
     st.equal(
       processor.processSync('It’s raining 🐱s and :dog:s. Now :3.').toString(),
       'It’s raining :cat:s and :dog:s. Now :man:.'
+    );
+
+    st.end();
+  });
+
+  t.test('should not encode things that are not emojis', function (st) {
+    var processor = retext().use(emoji, {
+      convert: 'encode',
+      emoticonModifierFn: 'use',
+      affixEmoticonModifier: 'use',
+      emojiModifier: 'useFirst'
+    });
+
+    st.equal(
+      processor.processSync('Beautiful URL https://www.example.org?dl=0 :)').toString(),
+      'Beautiful URL https://www.example.org?dl=0 😃'
+    );
+
+    st.end();
+  });
+
+  t.test('should not error on emojis only', function (st) {
+    var processor = retext().use(emoji, {convert: 'encode'});
+
+    st.equal(
+      processor.processSync('☕️☕️☕️☕️').toString(),
+      '☕️☕️☕️☕️'
     );
 
     st.end();


### PR DESCRIPTION
closes https://github.com/syntax-tree/nlcst-emoticon-modifier/issues/3

---

Hey @wooorm ! What about this? So this allows the use to pick between use and useFirst. Instead of modifying the plugin to 1 behavior this will allow me to test it in production for a while. I'm going to use this branch to see on the short/medium term what is the impact of it. If that's fine with you we can merge it. Or else, we can wait a few week so that I have more production data about it to find edge cases, and then pick afterwards.

To me it seems like the best combination so far is useFirst for emoji and use for affix & emoticon.